### PR TITLE
Issue analysis two

### DIFF
--- a/AINoval/lib/blocs/ai_config/ai_config_bloc.dart
+++ b/AINoval/lib/blocs/ai_config/ai_config_bloc.dart
@@ -630,7 +630,14 @@ class AiConfigBloc extends Bloc<AiConfigEvent, AiConfigState> {
 
       // 统一使用LoadModelsForProvider加载模型列表，不自动验证API Key
       AppLogger.i('AiConfigBloc', '触发加载 ${event.providerName} 的默认模型列表 (LoadModelsForProvider)');
-      add(LoadModelsForProvider(provider: event.providerName));
+      
+      // 添加事件去重或状态检查，避免无限循环
+      // 例如：检查是否已经在加载该提供商的模型
+      if (state.selectedProviderForModels != event.providerName || state.modelsForProviderInfo.isEmpty) {
+         add(LoadModelsForProvider(provider: event.providerName));
+      } else {
+         AppLogger.i('AiConfigBloc', '该提供商模型已加载，跳过重复请求');
+      }
       // --- 修改结束 ---
 
     } catch (e, stackTrace) {

--- a/AINoval/lib/screens/editor/widgets/novel_setting_sidebar.dart
+++ b/AINoval/lib/screens/editor/widgets/novel_setting_sidebar.dart
@@ -207,10 +207,19 @@ class _NovelSettingSidebarState extends State<NovelSettingSidebar>
           ElevatedButton(
             onPressed: () {
               Navigator.of(context).pop();
-              context.read<SettingBloc>().add(DeleteSettingGroup(
+              final settingBloc = context.read<SettingBloc>();
+              settingBloc.add(DeleteSettingGroup(
                 novelId: widget.novelId,
                 groupId: groupId,
               ));
+              
+              // 修复：删除后延迟刷新列表，确保 UI 更新
+              Future.delayed(const Duration(milliseconds: 500), () {
+                if (mounted) {
+                  AppLogger.i('NovelSettingSidebar', '删除设定组后刷新列表');
+                  settingBloc.add(LoadSettingGroups(widget.novelId));
+                }
+              });
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: WebTheme.error,


### PR DESCRIPTION
Fixes two issues: setting group deletion not refreshing UI and AI config repeatedly loading models.

Adds a delayed refresh after deleting a setting group to ensure the UI updates correctly. Optimizes AI config loading to prevent redundant API calls for models by checking if models for the selected provider are already loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f6474da-49ca-4f5c-9dfb-f0957b370d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f6474da-49ca-4f5c-9dfb-f0957b370d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

